### PR TITLE
Fix wrong `is` attribute on dynamic components

### DIFF
--- a/docs/nesting.md
+++ b/docs/nesting.md
@@ -483,7 +483,7 @@ Events and direct parent communication are a few of the ways to communicate back
 Sometimes, you may not know which child component should be rendered on a page until run-time. Therefore, Livewire allows you to choose a child component at run-time via `<livewire:dynamic-component ...>`, which receives an `:is` prop:
 
 ```blade
-<livewire:dynamic-component :is="$current" />
+<livewire:dynamic-component :component="$current" />
 ```
 
 Dynamic child components are useful in a variety of different scenarios, but below is an example of rendering different steps in a multi-step form using a dynamic component:
@@ -521,7 +521,7 @@ class Steps extends Component
 
 ```blade
 <div>
-    <livewire:dynamic-component :is="$current" />
+    <livewire:dynamic-component :component="$current" />
 
     <button wire:click="next">Next</button>
 </div>


### PR DESCRIPTION
It appears that docs are wrong on dynamic components and `component` must be used instead of `is` to specify component name. I bumped into this myself.

Relevant discussion: https://laracasts.com/discuss/channels/livewire/livewire-dynamic-component?page=1&replyId=902066

Cheers :)